### PR TITLE
Bump ordered-float to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,6 @@ keywords = ["parquet", "hadoop"]
 [dependencies]
 byteorder = "1.3"
 integer-encoding = { version = "3.0", features = ["futures_async"] }
-ordered-float = "1.0"
+ordered-float = "2.0"
 async-trait = {version = "0.1"}
 futures = {version = "0.3"}


### PR DESCRIPTION
Hey! We're thinking of using arrow2+parquet2 at https://github.com/MaterializeInc/materialize. To keep compiles speedy, we try to keep to a single version of each crate in our dep graph. We're already using 0.2 of ordered-float and parquet2 brings 0.1 in transitively through this.

I wasn't quite sure how to test this (or which branch to PR against). I see it publicly re-exported in mod thrift and then a use for that re-export in parquet_format.rs, but the latter doesn't seem to use OrderedFloat. I also don't see it used in parquet2. Everything seems to compile fine with this patch.

Thanks!